### PR TITLE
Run Guzzle tests using a httpbin container

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   gotify:
+    container_name: Gotify
     image: ghcr.io/gotify/server:2.1.0
     ports:
       - "127.0.0.1:8080:80"
@@ -10,3 +11,9 @@ services:
       - GOTIFY_DEFAULTUSER_PASS=admin
       - GOTIFY_DATABASE_DIALECT=sqlite3
       - GOTIFY_DATABASE_CONNECTION=/app/data/gotify.db
+
+  httpbin:
+    container_name: httpbin
+    image: kennethreitz/httpbin
+    ports:
+      - "127.0.0.1:8081:80"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSE_FILE: .ci/docker-compose.yml
-      GOTIFY_SERVER_URI: "http://127.0.0.1:8080"
+      GOTIFY_URI: "http://127.0.0.1:8080"
+      HTTPBIN_URI: "http://127.0.0.1:8081"
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
     - name: Install dependencies with composer
       run: composer install --prefer-dist
 
-    - name: Start gotify docker container
+    - name: Start gotify & httpbin docker containers
       run: docker-compose up -d
 
     - name: Run phpunit
       run: phpunit --configuration phpunit.xml
 
-    - name: Stop gotify docker container
+    - name: Stop gotify & httpbin docker docker containers
       run: docker-compose down

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -8,7 +8,7 @@ class GuzzleTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		self::$guzzle = new Guzzle(self::$httpBinUri);
+		self::$guzzle = new Guzzle(self::getHttpBinUri());
 	}
 
 	/**
@@ -98,7 +98,7 @@ class GuzzleTest extends TestCase
 			$password
 		);
 
-		$guzzle = new Gotify\Guzzle(self::$httpBinUri, $auth->get());
+		$guzzle = new Gotify\Guzzle(self::getHttpBinUri(), $auth->get());
 		$response = $guzzle->get('basic-auth/' . $username . '/' . $password);
 
 		$this->assertIsObject($response);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,7 +52,7 @@ abstract class TestCase extends BaseTestCase
 
 	/**
 	 * Retruns Gotify server URI
-	 * 
+	 *
 	 * Return value of `self::$gotifyUri` or environment variable `GOTIFY_URI` if set.
 	 */
 	protected static function getGotifyUri(): string
@@ -66,7 +66,7 @@ abstract class TestCase extends BaseTestCase
 
 	/**
 	 * Retruns httpbin server URI
-	 * 
+	 *
 	 * Return value of `self::$gotifyUri` or  environment variable `HTTPBIN_URI` if set.
 	 */
 	protected static function getHttpBinUri(): string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 abstract class TestCase extends BaseTestCase
 {
-	protected static string $serverUri = 'http://127.0.0.1:8080/';
+	protected static string $gotifyUri = 'http://127.0.0.1:8080/';
 	protected static string $httpBinUri = 'https://httpbin.org/';
 
 	protected static string $username = 'admin';
@@ -21,7 +21,7 @@ abstract class TestCase extends BaseTestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		self::$server = new Gotify\Server(self::$serverUri);
+		self::$server = new Gotify\Server(self::getGotifyUri());
 		self::$auth = new Gotify\Auth\User(self::$username, self::$password);
 	}
 
@@ -48,5 +48,33 @@ abstract class TestCase extends BaseTestCase
 		$encoded = base64_encode($imageData);
 
 		return 'data:' . $imageMimeType . ';base64,' . $encoded;
+	}
+
+	/**
+	 * Retruns Gotify server URI
+	 * 
+	 * Return value of `self::$gotifyUri` or environment variable `GOTIFY_URI` if set.
+	 */
+	protected static function getGotifyUri(): string
+	{
+		if (getenv('GOTIFY_URI') !== false) {
+			return getenv('GOTIFY_URI');
+		}
+
+		return self::$gotifyUri;
+	}
+
+	/**
+	 * Retruns httpbin server URI
+	 * 
+	 * Return value of `self::$gotifyUri` or  environment variable `HTTPBIN_URI` if set.
+	 */
+	protected static function getHttpBinUri(): string
+	{
+		if (getenv('HTTPBIN_URI') !== false) {
+			return getenv('HTTPBIN_URI');
+		}
+
+		return self::$httpBinUri;
 	}
 }


### PR DESCRIPTION
Updates tests and GitHub action to allow running Guzzle tests using a httpbin docker container instead of [httpbin.org](https://httpbin.org/).