### PR TITLE
[Guzzle] Add HTTP query support to get()

### DIFF
--- a/src/Gotify/Guzzle.php
+++ b/src/Gotify/Guzzle.php
@@ -43,11 +43,16 @@ final class Guzzle
 	 * Make GET request
 	 *
 	 * @param string $endpoint API endpoint
+	 * @param array<string, mixed> $query HTTP Query data
 	 * @return \stdClass|array<mixed>
 	 */
-	public function get(string $endpoint)
+	public function get(string $endpoint, array $query = array())
 	{
-		return $this->request('GET', $endpoint);
+		$options = array(
+			RequestOptions::QUERY => $query
+		);
+
+		return $this->request('GET', $endpoint, $options);
 	}
 
 	/**

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -17,7 +17,7 @@ class GuzzleTest extends TestCase
 	public function testGet(): void
 	{
 		$query = array(
-			'test' => 'HelloWorld' 
+			'test' => 'HelloWorld'
 		);
 
 		$response = self::$guzzle->get('get', $query);

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -16,7 +16,11 @@ class GuzzleTest extends TestCase
 	 */
 	public function testGet(): void
 	{
-		$response = self::$guzzle->get('get?test=HelloWorld');
+		$query = array(
+			'test' => 'HelloWorld' 
+		);
+
+		$response = self::$guzzle->get('get', $query);
 
 		$this->assertIsObject($response);
 		$this->assertObjectHasAttribute('args', $response);


### PR DESCRIPTION
Adds support for HTTP queries to method `get()` using GuzzleHttp's `RequestOptions`.