### PR TITLE
Refactor Endpoint methods & Guzzle class

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -26,7 +26,7 @@ API docs: [https://gotify.net/api-docs#/application](https://gotify.net/api-docs
 Get all applications
 
 ```PHP
-getAll(): array
+getAll(): stdClass
 ```
 
 Create an application
@@ -44,7 +44,7 @@ update(int $id, string $name, string $description): stdClass
 Delete an application
 
 ```PHP
-delete(int $id): null
+delete(int $id): boolean
 ```
 
 Upload image for an application
@@ -74,7 +74,7 @@ getAll(int $id, int $limit = 100, int $since = 0): stdClass
 Delete all messages for an application
 
 ```PHP
-deleteAll(int $id): null
+deleteAll(int $id): boolean
 ```
 
 ## Message
@@ -104,13 +104,13 @@ create(string $title, string $message, int $priority = 0, array $extras = array(
 Delete a message
 
 ```PHP
-delete(int $id): null
+delete(int $id): boolean
 ```
 
 Delete all messages
 
 ```PHP
-deleteAll(): null
+deleteAll(): boolean
 ```
 
 ## Client
@@ -128,7 +128,7 @@ API docs: [https://gotify.net/api-docs#/client](https://gotify.net/api-docs#/cli
 Get all clients
 
 ```PHP
-getAll(): array
+getAll()stdClass
 ```
 
 Create a client
@@ -146,7 +146,7 @@ Update a client
 Delete a client
 
 ```PHP
-delete(int $id): null
+delete(int $id): boolean
 ```
 
 ## User
@@ -170,7 +170,7 @@ getCurrent(): stdClass
 Update password for the current user
 
 ```PHP
-updatePassword(string $password): null
+updatePassword(string $password): boolean
 ```
 
 Get a user
@@ -182,7 +182,7 @@ getUser(int $id): stdClass
 Get all users
 
 ```PHP
-getAll(): array
+getAll()stdClass
 ```
 
 Create a user
@@ -194,7 +194,7 @@ create(string $name, string $password, bool $admin = false): stdClass
 Delete a user
 
 ```PHP
-delete(int $id): null
+delete(int $id): boolean
 ```
 
 ## Health

--- a/src/Gotify/Endpoint/Application.php
+++ b/src/Gotify/Endpoint/Application.php
@@ -74,11 +74,18 @@ class Application extends Api
 	 *
 	 * @param int $id Application Id
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function delete(int $id)
 	{
-		$this->guzzle->delete($this->endpoint . '/' . $id);
+		$response = $this->guzzle->delete($this->endpoint . '/' . $id);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Gotify/Endpoint/Application.php
+++ b/src/Gotify/Endpoint/Application.php
@@ -3,6 +3,7 @@
 namespace Gotify\Endpoint;
 
 Use Gotify\Api;
+Use Gotify\Json;
 
 /**
  * Class for interacting with application API endpoint
@@ -15,11 +16,14 @@ class Application extends Api
 	/**
 	 * Get all applications
 	 *
-	 * @return array<int, object>
+	 * @return \stdClass
 	 */
 	public function getAll()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$applications = Json::decode($response->getBody());
+
+		return (object) $applications;
 	}
 
 	/**
@@ -37,7 +41,10 @@ class Application extends Api
 			'description' => $description
 		);
 
-		return $this->guzzle->post($this->endpoint, $data);
+		$response = $this->guzzle->post($this->endpoint, $data);
+		$application = Json::decode($response->getBody());
+
+		return (object) $application;
 	}
 
 	/**
@@ -56,7 +63,10 @@ class Application extends Api
 			'description' => $description
 		);
 
-		return $this->guzzle->put($this->endpoint . '/' . $id, $data);
+		$response = $this->guzzle->put($this->endpoint . '/' . $id, $data);
+		$application = Json::decode($response->getBody());
+
+		return (object) $application;
 	}
 
 	/**
@@ -64,11 +74,11 @@ class Application extends Api
 	 *
 	 * @param int $id Application Id
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function delete(int $id)
 	{
-		return $this->guzzle->delete($this->endpoint . '/' . $id);
+		$this->guzzle->delete($this->endpoint . '/' . $id);
 	}
 
 	/**
@@ -85,6 +95,9 @@ class Application extends Api
 			'file' => $image
 		);
 
-		return $this->guzzle->postFile($this->endpoint . '/' . $id . '/image', $data);
+		$response = $this->guzzle->postFile($this->endpoint . '/' . $id . '/image', $data);
+		$application = Json::decode($response->getBody());
+
+		return (object) $application;
 	}
 }

--- a/src/Gotify/Endpoint/Application.php
+++ b/src/Gotify/Endpoint/Application.php
@@ -23,7 +23,7 @@ class Application extends Api
 		$response = $this->guzzle->get($this->endpoint);
 		$applications = Json::decode($response->getBody());
 
-		return (object) $applications;
+		return (object) ['apps' => $applications];
 	}
 
 	/**

--- a/src/Gotify/Endpoint/ApplicationMessage.php
+++ b/src/Gotify/Endpoint/ApplicationMessage.php
@@ -40,10 +40,17 @@ class ApplicationMessage extends Api
 	 *
 	 * @param int $id Application Id
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function deleteAll(int $id)
 	{
-		$this->guzzle->delete($this->endpoint . '/' . $id . '/message');
+		$response = $this->guzzle->delete($this->endpoint . '/' . $id . '/message');
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Gotify/Endpoint/ApplicationMessage.php
+++ b/src/Gotify/Endpoint/ApplicationMessage.php
@@ -2,7 +2,8 @@
 
 namespace Gotify\Endpoint;
 
-Use Gotify\Api;
+use Gotify\Api;
+use Gotify\Json;
 
 /**
  * Class for interacting with Application message API endpoint
@@ -28,7 +29,10 @@ class ApplicationMessage extends Api
 			'since' => $since
 		);
 
-		return $this->guzzle->get($this->endpoint . '/' . $id . '/message', $query);
+		$response = $this->guzzle->get($this->endpoint . '/' . $id . '/message', $query);
+		$messages = Json::decode($response->getBody());
+
+		return (object) $messages;
 	}
 
 	/**
@@ -36,10 +40,10 @@ class ApplicationMessage extends Api
 	 *
 	 * @param int $id Application Id
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function deleteAll(int $id)
 	{
-		return $this->guzzle->delete($this->endpoint . '/' . $id . '/message');
+		$this->guzzle->delete($this->endpoint . '/' . $id . '/message');
 	}
 }

--- a/src/Gotify/Endpoint/Client.php
+++ b/src/Gotify/Endpoint/Client.php
@@ -23,7 +23,7 @@ class Client extends Api
 		$response = $this->guzzle->get($this->endpoint);
 		$clients = Json::decode($response->getBody());
 
-		return (object) $clients;
+		return (object) ['clients' => $clients];
 	}
 
 	/**

--- a/src/Gotify/Endpoint/Client.php
+++ b/src/Gotify/Endpoint/Client.php
@@ -70,10 +70,17 @@ class Client extends Api
 	 *
 	 * @param int $id Client Id
 	 * 
-	 * @return void
+	 * @return boolean
 	 */
 	public function delete(int $id)
 	{
-		$this->guzzle->delete($this->endpoint . '/' . $id);
+		$response = $this->guzzle->delete($this->endpoint . '/' . $id);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Gotify/Endpoint/Client.php
+++ b/src/Gotify/Endpoint/Client.php
@@ -3,6 +3,7 @@
 namespace Gotify\Endpoint;
 
 Use Gotify\Api;
+Use Gotify\Json;
 
 /**
  * Class for interacting with client API endpoint
@@ -15,11 +16,14 @@ class Client extends Api
 	/**
 	 * Get all clients
 	 *
-	 * @return array<int, object>
+	 * @return \stdClass
 	 */
 	public function getAll()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$clients = Json::decode($response->getBody());
+
+		return (object) $clients;
 	}
 
 	/**
@@ -35,7 +39,10 @@ class Client extends Api
 			'name' => $name,
 		);
 
-		return $this->guzzle->post($this->endpoint, $data);
+		$response = $this->guzzle->post($this->endpoint, $data);
+		$client = Json::decode($response->getBody());
+
+		return (object) $client;
 	}
 
 	/**
@@ -52,18 +59,21 @@ class Client extends Api
 			'name' => $name,
 		);
 
-		return $this->guzzle->put($this->endpoint . '/' . $id, $data);
+		$response = $this->guzzle->put($this->endpoint . '/' . $id, $data);
+		$client = Json::decode($response->getBody());
+
+		return (object) $client;
 	}
 
 	/**
 	 * Delete a client
 	 *
 	 * @param int $id Client Id
-	 *
-	 * @return null
+	 * 
+	 * @return void
 	 */
 	public function delete(int $id)
 	{
-		return $this->guzzle->delete($this->endpoint . '/' . $id);
+		$this->guzzle->delete($this->endpoint . '/' . $id);
 	}
 }

--- a/src/Gotify/Endpoint/Client.php
+++ b/src/Gotify/Endpoint/Client.php
@@ -69,7 +69,7 @@ class Client extends Api
 	 * Delete a client
 	 *
 	 * @param int $id Client Id
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function delete(int $id)

--- a/src/Gotify/Endpoint/Health.php
+++ b/src/Gotify/Endpoint/Health.php
@@ -3,6 +3,7 @@
 namespace Gotify\Endpoint;
 
 Use Gotify\Api;
+Use Gotify\Json;
 
 /**
  * Class for interacting with health API endpoint
@@ -19,6 +20,9 @@ class Health extends Api
 	 */
 	public function get()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$health = Json::decode($response->getBody());
+
+		return (object) $health;
 	}
 }

--- a/src/Gotify/Endpoint/Message.php
+++ b/src/Gotify/Endpoint/Message.php
@@ -31,7 +31,7 @@ class Message extends Api
 		$response = $this->guzzle->get($this->endpoint, $query);
 		$messages = Json::decode($response->getBody());
 
-		return $messages;
+		return (object) $messages;
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Message extends Api
 		$response = $this->guzzle->post($this->endpoint, $data);
 		$message = Json::decode($response->getBody());
 
-		return $message;
+		return (object) $message;
 	}
 
 	/**

--- a/src/Gotify/Endpoint/Message.php
+++ b/src/Gotify/Endpoint/Message.php
@@ -66,21 +66,19 @@ class Message extends Api
 	 * Delete a message
 	 *
 	 * @param int $id Message Id
-	 *
-	 * @return null
+	 * @return void
 	 */
 	public function delete(int $id)
 	{
-		return $this->guzzle->delete($this->endpoint . '/' . $id);
+		$this->guzzle->delete($this->endpoint . '/' . $id);
 	}
 
 	/**
 	 * Delete all messages
-	 *
-	 * @return null
+	 * @return void
 	 */
 	public function deleteAll()
 	{
-		return $this->guzzle->delete($this->endpoint);
+		$this->guzzle->delete($this->endpoint);
 	}
 }

--- a/src/Gotify/Endpoint/Message.php
+++ b/src/Gotify/Endpoint/Message.php
@@ -3,6 +3,7 @@
 namespace Gotify\Endpoint;
 
 Use Gotify\Api;
+Use Gotify\Json;
 
 /**
  * Class for interacting with Message API endpoint
@@ -27,7 +28,10 @@ class Message extends Api
 			'since' => $since
 		);
 
-		return $this->guzzle->get($this->endpoint, $query);
+		$response = $this->guzzle->get($this->endpoint, $query);
+		$messages = Json::decode($response->getBody());
+
+		return $messages;
 	}
 
 	/**
@@ -52,7 +56,10 @@ class Message extends Api
 			$data['extras'] = $extras;
 		}
 
-		return $this->guzzle->post($this->endpoint, $data);
+		$response = $this->guzzle->post($this->endpoint, $data);
+		$message = Json::decode($response->getBody());
+
+		return $message;
 	}
 
 	/**

--- a/src/Gotify/Endpoint/Message.php
+++ b/src/Gotify/Endpoint/Message.php
@@ -66,19 +66,33 @@ class Message extends Api
 	 * Delete a message
 	 *
 	 * @param int $id Message Id
-	 * @return void
+	 * @return boolean
 	 */
 	public function delete(int $id)
 	{
-		$this->guzzle->delete($this->endpoint . '/' . $id);
+		$response = $this->guzzle->delete($this->endpoint . '/' . $id);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
 	 * Delete all messages
-	 * @return void
+	 * @return boolean
 	 */
 	public function deleteAll()
 	{
-		$this->guzzle->delete($this->endpoint);
+		$response = $this->guzzle->delete($this->endpoint);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Gotify/Endpoint/Plugin.php
+++ b/src/Gotify/Endpoint/Plugin.php
@@ -2,7 +2,8 @@
 
 namespace Gotify\Endpoint;
 
-Use Gotify\Api;
+use Gotify\Api;
+use Gotify\Json;
 
 /**
  * Class for interacting with plugin API endpoint
@@ -19,7 +20,10 @@ class Plugin extends Api
 	 */
 	public function getAll()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$plugins = Json::decode($response->getBody());
+
+		return (object) $plugins;
 	}
 
 	/**
@@ -31,7 +35,10 @@ class Plugin extends Api
 	 */
 	public function getConfig(int $id)
 	{
-		return $this->guzzle->get($this->endpoint . '/' . $id . '/config');
+		$response =  $this->guzzle->get($this->endpoint . '/' . $id . '/config');
+		$config = Json::decode($response->getBody());
+
+		return (object) $config;
 	}
 
 	/**
@@ -55,7 +62,10 @@ class Plugin extends Api
 	 */
 	public function getDisplayInfo(int $id)
 	{
-		return $this->guzzle->get($this->endpoint . '/' . $id . '/display');
+		$response =  $this->guzzle->get($this->endpoint . '/' . $id . '/display');;
+		$displayInfo = Json::decode($response->getBody());
+
+		return (object) $displayInfo;
 	}
 
 	/**
@@ -63,11 +73,11 @@ class Plugin extends Api
 	 *
 	 * @param int $id Plugin Id
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function enable(int $id)
 	{
-		return $this->guzzle->post($this->endpoint . '/' . $id . '/enable');
+		$this->guzzle->post($this->endpoint . '/' . $id . '/enable');
 	}
 
 	/**
@@ -75,10 +85,10 @@ class Plugin extends Api
 	 *
 	 * @param int $id Plugin Id
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function disable(int $id)
 	{
-		return $this->guzzle->post($this->endpoint . '/' . $id . '/disable');
+		$this->guzzle->post($this->endpoint . '/' . $id . '/disable');
 	}
 }

--- a/src/Gotify/Endpoint/Plugin.php
+++ b/src/Gotify/Endpoint/Plugin.php
@@ -73,11 +73,18 @@ class Plugin extends Api
 	 *
 	 * @param int $id Plugin Id
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function enable(int $id)
 	{
-		$this->guzzle->post($this->endpoint . '/' . $id . '/enable');
+		$response = $this->guzzle->post($this->endpoint . '/' . $id . '/enable');
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -85,10 +92,17 @@ class Plugin extends Api
 	 *
 	 * @param int $id Plugin Id
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function disable(int $id)
 	{
-		$this->guzzle->post($this->endpoint . '/' . $id . '/disable');
+		$response =  $this->guzzle->post($this->endpoint . '/' . $id . '/disable');
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Gotify/Endpoint/Plugin.php
+++ b/src/Gotify/Endpoint/Plugin.php
@@ -35,7 +35,7 @@ class Plugin extends Api
 	 */
 	public function getConfig(int $id)
 	{
-		$response =  $this->guzzle->get($this->endpoint . '/' . $id . '/config');
+		$response = $this->guzzle->get($this->endpoint . '/' . $id . '/config');
 		$config = Json::decode($response->getBody());
 
 		return (object) $config;
@@ -62,7 +62,7 @@ class Plugin extends Api
 	 */
 	public function getDisplayInfo(int $id)
 	{
-		$response =  $this->guzzle->get($this->endpoint . '/' . $id . '/display');;
+		$response = $this->guzzle->get($this->endpoint . '/' . $id . '/display');;
 		$displayInfo = Json::decode($response->getBody());
 
 		return (object) $displayInfo;
@@ -96,7 +96,7 @@ class Plugin extends Api
 	 */
 	public function disable(int $id)
 	{
-		$response =  $this->guzzle->post($this->endpoint . '/' . $id . '/disable');
+		$response = $this->guzzle->post($this->endpoint . '/' . $id . '/disable');
 		$body = $response->getBody()->getContents();
 
 		if (empty($body) === true) {

--- a/src/Gotify/Endpoint/User.php
+++ b/src/Gotify/Endpoint/User.php
@@ -2,7 +2,8 @@
 
 namespace Gotify\Endpoint;
 
-Use Gotify\Api;
+use Gotify\Api;
+use Gotify\Json;
 
 /**
  * Class for interacting with client user endpoint
@@ -19,7 +20,10 @@ class User extends Api
 	 */
 	public function getCurrent()
 	{
-		return $this->guzzle->get('current/user');
+		$response = $this->guzzle->get('current/user');
+		$current = Json::decode($response->getBody());
+
+		return (object) $current;
 	}
 
 	/**
@@ -27,7 +31,7 @@ class User extends Api
 	 *
 	 * @param string $password New password
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function updatePassword(string $password)
 	{
@@ -35,7 +39,7 @@ class User extends Api
 			'pass' => $password,
 		);
 
-		return $this->guzzle->post('current/user/password', $data);
+		$this->guzzle->post('current/user/password', $data);
 	}
 
 	/**
@@ -47,17 +51,23 @@ class User extends Api
 	 */
 	public function getUser(int $id)
 	{
-		return $this->guzzle->get($this->endpoint . '/' . $id);
+		$response = $this->guzzle->get($this->endpoint . '/' . $id);
+		$user = Json::decode($response->getBody());
+
+		return (object) $user;
 	}
 
 	/**
 	 * Get all users
 	 *
-	 * @return array<int, object>
+	 * @return \stdClass
 	 */
 	public function getAll()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$users = Json::decode($response->getBody());
+
+		return (object) $users;
 	}
 
 	/**
@@ -77,7 +87,10 @@ class User extends Api
 			'admin' => $admin
 		);
 
-		return $this->guzzle->post($this->endpoint, $data);
+		$response = $this->guzzle->post($this->endpoint, $data);
+		$user = Json::decode($response->getBody());
+
+		return (object) $user;
 	}
 
 	/**
@@ -85,10 +98,10 @@ class User extends Api
 	 *
 	 * @param int $id User Id
 	 *
-	 * @return null
+	 * @return void
 	 */
 	public function delete(int $id)
 	{
-		return $this->guzzle->delete($this->endpoint . '/' . $id);
+		$this->guzzle->delete($this->endpoint . '/' . $id);
 	}
 }

--- a/src/Gotify/Endpoint/User.php
+++ b/src/Gotify/Endpoint/User.php
@@ -31,7 +31,7 @@ class User extends Api
 	 *
 	 * @param string $password New password
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function updatePassword(string $password)
 	{
@@ -39,7 +39,14 @@ class User extends Api
 			'pass' => $password,
 		);
 
-		$this->guzzle->post('current/user/password', $data);
+		$response = $this->guzzle->post('current/user/password', $data);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -98,10 +105,17 @@ class User extends Api
 	 *
 	 * @param int $id User Id
 	 *
-	 * @return void
+	 * @return boolean
 	 */
 	public function delete(int $id)
 	{
-		$this->guzzle->delete($this->endpoint . '/' . $id);
+		$response = $this->guzzle->delete($this->endpoint . '/' . $id);
+		$body = $response->getBody()->getContents();
+
+		if (empty($body) === true) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Gotify/Endpoint/User.php
+++ b/src/Gotify/Endpoint/User.php
@@ -74,7 +74,7 @@ class User extends Api
 		$response = $this->guzzle->get($this->endpoint);
 		$users = Json::decode($response->getBody());
 
-		return (object) $users;
+		return (object) ['users' => $users];
 	}
 
 	/**

--- a/src/Gotify/Endpoint/Version.php
+++ b/src/Gotify/Endpoint/Version.php
@@ -2,7 +2,8 @@
 
 namespace Gotify\Endpoint;
 
-Use Gotify\Api;
+use Gotify\Api;
+use Gotify\Json;
 
 /**
  * Class for interacting with version API endpoint
@@ -19,6 +20,9 @@ class Version extends Api
 	 */
 	public function get()
 	{
-		return $this->guzzle->get($this->endpoint);
+		$response = $this->guzzle->get($this->endpoint);
+		$version = Json::decode($response->getBody());
+
+		return (object) $version;
 	}
 }

--- a/src/Gotify/Guzzle.php
+++ b/src/Gotify/Guzzle.php
@@ -156,7 +156,7 @@ final class Guzzle
 			$contentType = $response->getHeaderLine('Content-Type');
 
 			if ($contentType === 'application/json') {
-				$json = Json::decode($response->getBody());
+				$json = (object) Json::decode($response->getBody());
 				$message = $json->error . ': ' . $json->errorDescription . ' (' . $json->errorCode . ')';
 
 				throw new EndpointException($message, $json->errorCode);

--- a/src/Gotify/Guzzle.php
+++ b/src/Gotify/Guzzle.php
@@ -5,6 +5,7 @@ namespace Gotify;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
 
 use InvalidArgumentException;
 use Gotify\Exception\GotifyException;
@@ -44,7 +45,7 @@ final class Guzzle
 	 *
 	 * @param string $endpoint API endpoint
 	 * @param array<string, mixed> $query HTTP Query data
-	 * @return \stdClass|array<mixed>
+	 * @return ResponseInterface
 	 */
 	public function get(string $endpoint, array $query = array())
 	{
@@ -60,7 +61,7 @@ final class Guzzle
 	 *
 	 * @param string $endpoint API endpoint
 	 * @param array<string, mixed> $data
-	 * @return \stdClass|null
+	 * @return ResponseInterface
 	 */
 	public function post(string $endpoint, array $data = array())
 	{
@@ -76,7 +77,7 @@ final class Guzzle
 	 *
 	 * @param string $endpoint API endpoint
 	 * @param array<string, string> $data
-	 * @return \stdClass
+	 * @return ResponseInterface
 	 *
 	 * @throws GotifyException if the file cannot be opened
 	 */
@@ -101,7 +102,7 @@ final class Guzzle
 	 *
 	 * @param string $endpoint API endpoint
 	 * @param array<string, string> $data
-	 * @return \stdClass
+	 * @return ResponseInterface
 	 */
 	public function put(string $endpoint, array $data)
 	{
@@ -116,7 +117,7 @@ final class Guzzle
 	 * Make DELETE request
 	 *
 	 * @param string $endpoint API endpoint
-	 * @return \stdClass|null
+	 * @return ResponseInterface
 	 */
 	public function delete(string $endpoint)
 	{
@@ -129,7 +130,7 @@ final class Guzzle
 	 * @param string $method HTTP request method
 	 * @param string $endpoint API endpoint
 	 * @param array<string, mixed> $options HTTP request options
-	 * @return mixed
+	 * @return ResponseInterface
 	 *
 	 * @throws InvalidArgumentException if HTTP request method is not supported
 	 * @throws EndpointException if API returned an error
@@ -164,11 +165,7 @@ final class Guzzle
 			throw new EndpointException($err->getMessage(), $response->getStatusCode());
 		}
 
-		if (empty($response->getBody()->getContents())) { // Some requests do not return anything
-			return null;
-		}
-
-		return Json::decode($response->getBody());
+		return $response;
 	}
 
 	/**

--- a/tests/Endpoints/ApplicationMessageTest.php
+++ b/tests/Endpoints/ApplicationMessageTest.php
@@ -53,6 +53,8 @@ class ApplicationMessageTest extends TestCase
 	public function testDeleteAll(): void
 	{
 		$deleted = self::$applicationMessage->deleteAll(self::$appId);
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 }

--- a/tests/Endpoints/ApplicationTest.php
+++ b/tests/Endpoints/ApplicationTest.php
@@ -47,16 +47,20 @@ class ApplicationTest extends TestCase
 	 */
 	public function testGetAll(): void
 	{
-		$apps = self::$application->getAll();
+		$applications = self::$application->getAll();
 
-		$this->assertIsArray($apps);
+		$this->assertIsObject($applications);
+		$this->assertObjectHasAttribute('apps', $applications);
 
-		if (count($apps) > 0) {
-			$this->assertIsObject($apps[0]);
-			$this->assertObjectHasAttribute('id', $apps[0]);
-			$this->assertObjectHasAttribute('name', $apps[0]);
-			$this->assertObjectHasAttribute('description', $apps[0]);
-			$this->assertObjectHasAttribute('token', $apps[0]);
+		if (count($applications->apps) > 0) {
+			$this->assertIsObject($applications->apps[0]);
+
+			$app = $applications->apps[0];
+
+			$this->assertObjectHasAttribute('id', $app);
+			$this->assertObjectHasAttribute('name', $app);
+			$this->assertObjectHasAttribute('description', $app);
+			$this->assertObjectHasAttribute('token', $app);
 		}
 	}
 
@@ -106,6 +110,8 @@ class ApplicationTest extends TestCase
 	public function testDelete(): void
 	{
 		$deleted = self::$application->delete(self::$appId);
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 }

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -46,13 +46,18 @@ class ClientTest extends TestCase
 	{
 		$clients = self::$client->getAll();
 
-		$this->assertIsArray($clients);
+		$this->assertIsObject($clients);
+		$this->assertIsObject($clients);
+		$this->assertObjectHasAttribute('clients', $clients);
 
-		if (count($clients) > 0) {
-			$this->assertIsObject($clients[0]);
-			$this->assertObjectHasAttribute('id', $clients[0]);
-			$this->assertObjectHasAttribute('name', $clients[0]);
-			$this->assertObjectHasAttribute('token', $clients[0]);
+		if (count($clients->clients) > 0) {
+			$this->assertIsObject($clients->clients[0]);
+
+			$client = $clients->clients[0];
+
+			$this->assertObjectHasAttribute('id', $client);
+			$this->assertObjectHasAttribute('name', $client);
+			$this->assertObjectHasAttribute('token', $client);
 		}
 	}
 
@@ -84,6 +89,8 @@ class ClientTest extends TestCase
 	public function testDelete(): void
 	{
 		$deleted = self::$client->delete(self::$clientId);
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 }

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -47,7 +47,6 @@ class ClientTest extends TestCase
 		$clients = self::$client->getAll();
 
 		$this->assertIsObject($clients);
-		$this->assertIsObject($clients);
 		$this->assertObjectHasAttribute('clients', $clients);
 
 		if (count($clients->clients) > 0) {

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -81,7 +81,9 @@ class MessageTest extends TestCase
 	public function testDelete(): void
 	{
 		$deleted = self::$message->delete(self::$messageId);
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 
 	/**
@@ -90,6 +92,8 @@ class MessageTest extends TestCase
 	public function testDeleteAll(): void
 	{
 		$deleted = self::$message->deleteAll();
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 }

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -52,10 +52,11 @@ class UserTest extends TestCase
 	{
 		$users = self::$user->getAll();
 
-		$this->assertIsArray($users);
+		$this->assertIsObject($users);
+		$this->assertObjectHasAttribute('users', $users);
 
-		if (count($users) > 0) {
-			$this->assertIsObject($users[0]);
+		if (count($users->users) > 0) {
+			$this->assertIsObject($users->users[0]);
 		}
 	}
 
@@ -89,7 +90,9 @@ class UserTest extends TestCase
 		);
 
 		$updated = $user->updatePassword('NewPassword');
-		$this->assertNull($updated);
+
+		$this->assertIsBool($updated);
+		$this->assertEquals(true, $updated);
 	}
 
 	/**
@@ -100,6 +103,8 @@ class UserTest extends TestCase
 	public function testDelete(): void
 	{
 		$deleted = self::$user->delete(self::$userId);
-		$this->assertNull($deleted);
+
+		$this->assertIsBool($deleted);
+		$this->assertEquals(true, $deleted);
 	}
 }

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Gotify\Guzzle;
+use Gotify\Json;
 
 class GuzzleTest extends TestCase
 {
@@ -21,11 +22,12 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->get('get', $query);
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('args', $response);
-		$this->assertObjectHasAttribute('test', $response->args);
-		$this->assertEquals('HelloWorld', $response->args->test);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('args', $body);
+		$this->assertObjectHasAttribute('test', $body->args);
+		$this->assertEquals('HelloWorld', $body->args->test);
 	}
 
 	/**
@@ -38,11 +40,12 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->post('post', $data);
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('json', $response);
-		$this->assertObjectHasAttribute('test', $response->json);
-		$this->assertEquals('HelloWorld', $response->json->test);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('json', $body);
+		$this->assertObjectHasAttribute('test', $body->json);
+		$this->assertEquals('HelloWorld', $body->json->test);
 	}
 
 	/**
@@ -55,11 +58,12 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->postFile('post', $data);
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('files', $response);
-		$this->assertObjectHasAttribute('file', $response->files);
-		$this->assertEquals($this->getAppImageBase64(), $response->files->file);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('files', $body);
+		$this->assertObjectHasAttribute('file', $body->files);
+		$this->assertEquals($this->getAppImageBase64(), $body->files->file);
 	}
 
 	/**
@@ -72,11 +76,12 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->put('put', $data);
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('json', $response);
-		$this->assertObjectHasAttribute('test', $response->json);
-		$this->assertEquals('HelloWorld', $response->json->test);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('json', $body);
+		$this->assertObjectHasAttribute('test', $body->json);
+		$this->assertEquals('HelloWorld', $body->json->test);
 	}
 
 	/**
@@ -84,9 +89,10 @@ class GuzzleTest extends TestCase
 	 */
 	public function testDelete(): void
 	{
-		$response = self::$guzzle->delete('delete');
+		$response =  self::$guzzle->delete('delete');
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
+		$this->assertIsObject($body);
 	}
 
 	/**
@@ -103,14 +109,16 @@ class GuzzleTest extends TestCase
 		);
 
 		$guzzle = new Gotify\Guzzle(self::getHttpBinUri(), $auth->get());
+
 		$response = $guzzle->get('basic-auth/' . $username . '/' . $password);
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('authenticated', $response);
-		$this->assertObjectHasAttribute('user', $response);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('authenticated', $body);
+		$this->assertObjectHasAttribute('user', $body);
 
-		$this->assertEquals(true, $response->authenticated);
-		$this->assertEquals($username, $response->user);
+		$this->assertEquals(true, $body->authenticated);
+		$this->assertEquals($username, $body->user);
 	}
 
 	/**
@@ -123,13 +131,15 @@ class GuzzleTest extends TestCase
 		$auth = new \Gotify\Auth\Token($token);
 
 		$guzzle = new Gotify\Guzzle(self::$httpBinUri, $auth->get());
+		
 		$response = $guzzle->get('get');
+		$body = Json::decode($response->getBody());
 
-		$this->assertIsObject($response);
-		$this->assertObjectHasAttribute('headers', $response);
-		$this->assertObjectHasAttribute('X-Gotify-Key', $response->headers);
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('headers', $body);
+		$this->assertObjectHasAttribute('X-Gotify-Key', $body->headers);
 
-		$headers = get_object_vars($response->headers);
+		$headers = get_object_vars($body->headers);
 
 		$this->assertEquals($token, $headers['X-Gotify-Key']);
 	}

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -22,7 +22,7 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->get('get', $query);
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('args', $body);
@@ -40,7 +40,7 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->post('post', $data);
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('json', $body);
@@ -58,7 +58,7 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->postFile('post', $data);
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('files', $body);
@@ -76,7 +76,7 @@ class GuzzleTest extends TestCase
 		);
 
 		$response = self::$guzzle->put('put', $data);
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('json', $body);
@@ -90,7 +90,7 @@ class GuzzleTest extends TestCase
 	public function testDelete(): void
 	{
 		$response =  self::$guzzle->delete('delete');
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 	}
@@ -111,7 +111,7 @@ class GuzzleTest extends TestCase
 		$guzzle = new Gotify\Guzzle(self::getHttpBinUri(), $auth->get());
 
 		$response = $guzzle->get('basic-auth/' . $username . '/' . $password);
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('authenticated', $body);
@@ -133,7 +133,7 @@ class GuzzleTest extends TestCase
 		$guzzle = new Gotify\Guzzle(self::$httpBinUri, $auth->get());
 		
 		$response = $guzzle->get('get');
-		$body = Json::decode($response->getBody());
+		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
 		$this->assertObjectHasAttribute('headers', $body);

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -89,7 +89,7 @@ class GuzzleTest extends TestCase
 	 */
 	public function testDelete(): void
 	{
-		$response =  self::$guzzle->delete('delete');
+		$response = self::$guzzle->delete('delete');
 		$body = (object) Json::decode($response->getBody());
 
 		$this->assertIsObject($body);
@@ -131,7 +131,7 @@ class GuzzleTest extends TestCase
 		$auth = new \Gotify\Auth\Token($token);
 
 		$guzzle = new Gotify\Guzzle(self::$httpBinUri, $auth->get());
-		
+
 		$response = $guzzle->get('get');
 		$body = (object) Json::decode($response->getBody());
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,7 @@ abstract class TestCase extends BaseTestCase
 	 */
 	protected function getAppImageBase64(): string
 	{
-		$imageData = file_get_contents($this->getAppImagePath());
+		$imageData = (string) file_get_contents($this->getAppImagePath());
 		$imageMimeType = mime_content_type($this->getAppImagePath());
 
 		$encoded = base64_encode($imageData);


### PR DESCRIPTION
Changes:
* All endpoint methods that return data now use `stdClass`.
* All endpoint methods that do not return data now return a `boolean`.
* Guzzle method `request()` no longer returns decoded JSON, instead it returns `Psr\Http\Message\ResponseInterface`. JSON decoding is handled by each endpoint method.