### PR TITLE
Add unit tests for methods handling YAML

### DIFF
--- a/tests/Endpoints/PluginTest.php
+++ b/tests/Endpoints/PluginTest.php
@@ -47,6 +47,21 @@ class PluginTest extends TestCase
 		$this->assertNotEmpty($config);
 	}
 
+	/**
+	 * Test updating config for a plugin
+	 */
+	public function testUpdateConfig(): void
+	{
+		$updated = self::$plugin->updateConfig(self::$pluginId, $this->getYaml());
+
+		$this->assertIsBool($updated);
+		$this->assertEquals(true, $updated);
+
+		$config = self::$plugin->getConfig(self::$pluginId);
+
+		$this->assertEquals($config, $this->getYaml());
+	}
+
 	public function testGetDisplayInfo(): void
 	{
 		$info = self::$plugin->getDisplayInfo(self::$pluginId);

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -49,6 +49,21 @@ class GuzzleTest extends TestCase
 	}
 
 	/**
+	 * Test making a POST request with a YAML body
+	 */
+	public function testPostYaml(): void
+	{
+		$data = $this->getYaml();
+
+		$response = self::$guzzle->PostYaml('post', $data);
+		$body = (object) Json::decode($response->getBody());
+
+		$this->assertIsObject($body);
+		$this->assertObjectHasAttribute('data', $body);
+		$this->assertEquals($data, $body->data);
+	}
+
+	/**
 	 * Test making a POST request with a file
 	 */
 	public function testPostFile(): void

--- a/tests/TestAssets/broadcaster-config.yaml
+++ b/tests/TestAssets/broadcaster-config.yaml
@@ -1,0 +1,26 @@
+channels:
+- name: example
+  public: false
+sender_filter:
+- match:
+  - mode: user_name
+    user_name: my_server
+  - mode: message_text
+    regex: true
+    message_text: ^\[(INFO|DEBUG)\]
+  action: reject
+- match:
+  - mode: user_name
+    user_name: some_one_i_dont_want_to_see_broadcast_from
+  action: reject
+- match:
+  - mode: any
+  action: accept
+receiver_filter:
+- match:
+  - mode: user_name
+    user_name: some_one_i_dont_want_to_send_broadcast_to
+  action: reject
+- match:
+  - mode: any
+  action: accept

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ abstract class TestCase extends BaseTestCase
 	protected static string $password = 'admin';
 
 	protected string $appImage = 'appImage.png';
+	protected string $yaml = 'broadcaster-config.yaml';
 
 	protected static Gotify\Server $server;
 	protected static Gotify\Auth\User $auth;
@@ -23,6 +24,18 @@ abstract class TestCase extends BaseTestCase
 	{
 		self::$server = new Gotify\Server(self::getGotifyUri());
 		self::$auth = new Gotify\Auth\User(self::$username, self::$password);
+	}
+
+	/**
+	 * Retruns YAML path
+	 */
+	protected function getYamlPath(): string
+	{
+		$path = __DIR__ . '/TestAssets/' . $this->yaml;
+
+		$this->assertFileExists($path);
+
+		return $path;
 	}
 
 	/**
@@ -48,6 +61,15 @@ abstract class TestCase extends BaseTestCase
 		$encoded = base64_encode($imageData);
 
 		return 'data:' . $imageMimeType . ';base64,' . $encoded;
+	}
+
+	/**
+	 * Retruns example broadcaster config YAML
+	 */
+	protected function getYaml(): string
+	{
+		$data = (string) file_get_contents($this->getYamlPath());
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
Adds unit tests for `Gotify\Endpoint\Plugin\updateConfig()` and `Gotify\Guzzle\postYaml()`