### PR TITLE
[phpunit] Exclude PluginTest.php from test suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
   <testsuites>
     <testsuite name="gotify-api-php">
       <directory suffix=".php">./tests/</directory>
+      <exclude>./tests/Endpoints/PluginTest.php</exclude>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
Excludes `PluginTest.php` from phpunit test suite as the plugin ([gotify-broadcast](https://github.com/eternal-flame-AD/gotify-broadcast)) used for the tests does not currently have a build for gotify version 2.1.7.