### PR TITLE
Bump gotify/server version  (2.2.4 => 2.2.5) 

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   gotify:
     container_name: ci_gotify
-    image: gotify/server:2.2.4
+    image: gotify/server:2.2.5
     ports:
       - "127.0.0.1:8080:80"
     environment:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   gotify:
     container_name: gotify
-    image: gotify/server:2.2.4
+    image: gotify/server:2.2.5
     ports:
       - "8080:80"
     environment:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 PHP library for interacting with a [Gotify](https://github.com/gotify/server) server using the [Gotify REST-API](https://gotify.net/api-docs).
 
-Supports Gotify server version 2.2.4.
+Supports Gotify server version 2.2.5.
 
 ## Install
 


### PR DESCRIPTION
https://github.com/gotify/server/releases/tag/v2.2.5