### PR TITLE
Bump gotify/server version (2.2.5 => 2.3.0)

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   gotify:
     container_name: ci_gotify
-    image: gotify/server:2.2.5
+    image: gotify/server:2.3.0
     ports:
       - "127.0.0.1:8080:80"
     environment:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   gotify:
     container_name: gotify
-    image: gotify/server:2.2.5
+    image: gotify/server:2.3.0
     ports:
       - "8080:80"
     environment:


### PR DESCRIPTION
https://github.com/gotify/server/releases/tag/v2.3.0