### PR TITLE
tests: Use `assertObjectHasProperty()`

### DIFF
--- a/tests/Endpoints/ApplicationMessageTest.php
+++ b/tests/Endpoints/ApplicationMessageTest.php
@@ -47,7 +47,7 @@ class ApplicationMessageTest extends TestCase
         $messages = self::$applicationMessage->getAll(self::$appId);
 
         $this->assertIsObject($messages);
-        $this->assertObjectHasAttribute('messages', $messages);
+        $this->assertObjectHasProperty('messages', $messages);
     }
 
     /**

--- a/tests/Endpoints/ApplicationTest.php
+++ b/tests/Endpoints/ApplicationTest.php
@@ -32,9 +32,9 @@ class ApplicationTest extends TestCase
         );
 
         $this->assertIsObject($created);
-        $this->assertObjectHasAttribute('id', $created);
-        $this->assertObjectHasAttribute('name', $created);
-        $this->assertObjectHasAttribute('description', $created);
+        $this->assertObjectHasProperty('id', $created);
+        $this->assertObjectHasProperty('name', $created);
+        $this->assertObjectHasProperty('description', $created);
 
         $this->assertEquals($name, $created->name);
         $this->assertEquals($description, $created->description);
@@ -52,17 +52,17 @@ class ApplicationTest extends TestCase
         $applications = self::$application->getAll();
 
         $this->assertIsObject($applications);
-        $this->assertObjectHasAttribute('apps', $applications);
+        $this->assertObjectHasProperty('apps', $applications);
 
         if (count($applications->apps) > 0) {
             $this->assertIsObject($applications->apps[0]);
 
             $app = $applications->apps[0];
 
-            $this->assertObjectHasAttribute('id', $app);
-            $this->assertObjectHasAttribute('name', $app);
-            $this->assertObjectHasAttribute('description', $app);
-            $this->assertObjectHasAttribute('token', $app);
+            $this->assertObjectHasProperty('id', $app);
+            $this->assertObjectHasProperty('name', $app);
+            $this->assertObjectHasProperty('description', $app);
+            $this->assertObjectHasProperty('token', $app);
         }
     }
 
@@ -83,8 +83,8 @@ class ApplicationTest extends TestCase
         );
 
         $this->assertIsObject($updated);
-        $this->assertObjectHasAttribute('name', $updated);
-        $this->assertObjectHasAttribute('description', $updated);
+        $this->assertObjectHasProperty('name', $updated);
+        $this->assertObjectHasProperty('description', $updated);
 
         $this->assertEquals($name, $updated->name);
         $this->assertEquals($description, $updated->description);
@@ -101,7 +101,7 @@ class ApplicationTest extends TestCase
         $uploaded = self::$application->uploadImage(self::$appId, $path);
 
         $this->assertIsObject($uploaded);
-        $this->assertObjectHasAttribute('image', $uploaded);
+        $this->assertObjectHasProperty('image', $uploaded);
     }
 
     /**

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -30,9 +30,9 @@ class ClientTest extends TestCase
         );
 
         $this->assertIsObject($client);
-        $this->assertObjectHasAttribute('id', $client);
-        $this->assertObjectHasAttribute('name', $client);
-        $this->assertObjectHasAttribute('token', $client);
+        $this->assertObjectHasProperty('id', $client);
+        $this->assertObjectHasProperty('name', $client);
+        $this->assertObjectHasProperty('token', $client);
 
         $this->assertEquals($name, $client->name);
 
@@ -49,16 +49,16 @@ class ClientTest extends TestCase
         $clients = self::$client->getAll();
 
         $this->assertIsObject($clients);
-        $this->assertObjectHasAttribute('clients', $clients);
+        $this->assertObjectHasProperty('clients', $clients);
 
         if (count($clients->clients) > 0) {
             $this->assertIsObject($clients->clients[0]);
 
             $client = $clients->clients[0];
 
-            $this->assertObjectHasAttribute('id', $client);
-            $this->assertObjectHasAttribute('name', $client);
-            $this->assertObjectHasAttribute('token', $client);
+            $this->assertObjectHasProperty('id', $client);
+            $this->assertObjectHasProperty('name', $client);
+            $this->assertObjectHasProperty('token', $client);
         }
     }
 
@@ -77,7 +77,7 @@ class ClientTest extends TestCase
         );
 
         $this->assertIsObject($updated);
-        $this->assertObjectHasAttribute('name', $updated);
+        $this->assertObjectHasProperty('name', $updated);
 
         $this->assertEquals($name, $updated->name);
     }

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -67,10 +67,10 @@ class MessageTest extends TestCase
         );
 
         $this->assertIsObject($message);
-        $this->assertObjectHasAttribute('id', $message);
-        $this->assertObjectHasAttribute('title', $message);
-        $this->assertObjectHasAttribute('message', $message);
-        $this->assertObjectHasAttribute('priority', $message);
+        $this->assertObjectHasProperty('id', $message);
+        $this->assertObjectHasProperty('title', $message);
+        $this->assertObjectHasProperty('message', $message);
+        $this->assertObjectHasProperty('priority', $message);
 
         $this->assertEquals(self::$testTitle, $message->title);
         $this->assertEquals(self::$testMessage, $message->message);
@@ -107,10 +107,10 @@ class MessageTest extends TestCase
         );
 
         $this->assertIsObject($message);
-        $this->assertObjectHasAttribute('extras', $message);
-        $this->assertObjectHasAttribute('client::notification', $message->extras);
-        $this->assertObjectHasAttribute('click', $message->extras->{'client::notification'});
-        $this->assertObjectHasAttribute('url', $message->extras->{'client::notification'}->click);
+        $this->assertObjectHasProperty('extras', $message);
+        $this->assertObjectHasProperty('client::notification', $message->extras);
+        $this->assertObjectHasProperty('click', $message->extras->{'client::notification'});
+        $this->assertObjectHasProperty('url', $message->extras->{'client::notification'}->click);
 
         $this->assertEquals(
             $extras['client::notification']['click']['url'],
@@ -126,7 +126,7 @@ class MessageTest extends TestCase
         $messages = self::$message->getAll();
 
         $this->assertIsObject($messages);
-        $this->assertObjectHasAttribute('messages', $messages);
+        $this->assertObjectHasProperty('messages', $messages);
     }
 
     /**

--- a/tests/Endpoints/PluginTest.php
+++ b/tests/Endpoints/PluginTest.php
@@ -26,16 +26,16 @@ class PluginTest extends TestCase
         $plugins = self::$plugin->getAll();
 
         $this->assertIsObject($plugins);
-        $this->assertObjectHasAttribute('plugins', $plugins);
+        $this->assertObjectHasProperty('plugins', $plugins);
 
         if (count($plugins->plugins) > 0) {
             $this->assertIsObject($plugins->plugins[0]);
 
             $plugin = $plugins->plugins[0];
 
-            $this->assertObjectHasAttribute('id', $plugin);
-            $this->assertObjectHasAttribute('name', $plugin);
-            $this->assertObjectHasAttribute('token', $plugin);
+            $this->assertObjectHasProperty('id', $plugin);
+            $this->assertObjectHasProperty('name', $plugin);
+            $this->assertObjectHasProperty('token', $plugin);
         }
     }
 

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -31,9 +31,9 @@ class UserTest extends TestCase
 
         $this->assertIsObject($current);
 
-        $this->assertObjectHasAttribute('id', $current);
-        $this->assertObjectHasAttribute('name', $current);
-        $this->assertObjectHasAttribute('admin', $current);
+        $this->assertObjectHasProperty('id', $current);
+        $this->assertObjectHasProperty('name', $current);
+        $this->assertObjectHasProperty('admin', $current);
 
         $this->assertEquals(self::$username, $current->name);
     }
@@ -56,7 +56,7 @@ class UserTest extends TestCase
         $users = self::$user->getAll();
 
         $this->assertIsObject($users);
-        $this->assertObjectHasAttribute('users', $users);
+        $this->assertObjectHasProperty('users', $users);
 
         if (count($users->users) > 0) {
             $this->assertIsObject($users->users[0]);
@@ -113,8 +113,8 @@ class UserTest extends TestCase
         );
 
         $this->assertIsObject($updated);
-        $this->assertObjectHasAttribute('name', $updated);
-        $this->assertObjectHasAttribute('id', $updated);
+        $this->assertObjectHasProperty('name', $updated);
+        $this->assertObjectHasProperty('id', $updated);
 
         $this->assertEquals(self::$userId, $updated->id);
         $this->assertEquals($newTestUsername, $updated->name);

--- a/tests/GuzzleTest.php
+++ b/tests/GuzzleTest.php
@@ -27,8 +27,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('args', $body);
-        $this->assertObjectHasAttribute('test', $body->args);
+        $this->assertObjectHasProperty('args', $body);
+        $this->assertObjectHasProperty('test', $body->args);
         $this->assertEquals('HelloWorld', $body->args->test[0]);
     }
 
@@ -45,8 +45,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('json', $body);
-        $this->assertObjectHasAttribute('test', $body->json);
+        $this->assertObjectHasProperty('json', $body);
+        $this->assertObjectHasProperty('test', $body->json);
         $this->assertEquals('HelloWorld', $body->json->test);
     }
 
@@ -61,7 +61,7 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('data', $body);
+        $this->assertObjectHasProperty('data', $body);
         $this->assertEquals($this->getYamlBase64(), $body->data);
     }
 
@@ -78,8 +78,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('files', $body);
-        $this->assertObjectHasAttribute('file', $body->files);
+        $this->assertObjectHasProperty('files', $body);
+        $this->assertObjectHasProperty('file', $body->files);
         $this->assertEquals(file_get_contents($this->getTextFilePath()), $body->files->file[0]);
     }
 
@@ -96,8 +96,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('json', $body);
-        $this->assertObjectHasAttribute('test', $body->json);
+        $this->assertObjectHasProperty('json', $body);
+        $this->assertObjectHasProperty('test', $body->json);
         $this->assertEquals('HelloWorld', $body->json->test);
     }
 
@@ -131,8 +131,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('authorized', $body);
-        $this->assertObjectHasAttribute('user', $body);
+        $this->assertObjectHasProperty('authorized', $body);
+        $this->assertObjectHasProperty('user', $body);
 
         $this->assertEquals(true, $body->authorized);
         $this->assertEquals($username, $body->user);
@@ -153,8 +153,8 @@ class GuzzleTest extends TestCase
         $body = (object) Json::decode($response->getBody());
 
         $this->assertIsObject($body);
-        $this->assertObjectHasAttribute('headers', $body);
-        $this->assertObjectHasAttribute('X-Gotify-Key', $body->headers);
+        $this->assertObjectHasProperty('headers', $body);
+        $this->assertObjectHasProperty('X-Gotify-Key', $body->headers);
 
         $headers = get_object_vars($body->headers);
 


### PR DESCRIPTION
Replaces deprecated PHPUnit method `assertObjectHasAttribute()` with `assertObjectHasProperty()` added in [version 9.6.11](https://github.com/VerifiedJoseph/gotify-api-php/pull/258).