### PR TITLE
Guzzle: Fix deprecation notice in `getConfig`

### DIFF
--- a/src/Guzzle.php
+++ b/src/Guzzle.php
@@ -192,7 +192,7 @@ class Guzzle
      *
      * @return array<string, mixed> Returns client config array
      */
-    private function getConfig(string $uri, null|User|Token $auth = null, ?HandlerStack $handlerStack): array
+    private function getConfig(string $uri, null|User|Token $auth = null, ?HandlerStack $handlerStack = null): array
     {
         $config = [
             'base_uri' => $uri,


### PR DESCRIPTION
 Fixes deprecation notice in Guzzle class function `getConfig`. closes #490

> Deprecated: Optional parameter $auth declared before required parameter $handlerStack is implicitly treated as a required parameter in verifiedjoseph/gotify-api-php/src/Guzzle.php on line 195