### PR TITLE
tests: Remove checking for token in `getAll` method tests

### DIFF
--- a/tests/Endpoints/ApplicationTest.php
+++ b/tests/Endpoints/ApplicationTest.php
@@ -75,7 +75,6 @@ class ApplicationTest extends AbstractTestCase
             $this->assertObjectHasProperty('id', $app);
             $this->assertObjectHasProperty('name', $app);
             $this->assertObjectHasProperty('description', $app);
-            $this->assertObjectHasProperty('token', $app);
         }
     }
 

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -70,7 +70,6 @@ class ClientTest extends AbstractTestCase
 
             $this->assertObjectHasProperty('id', $client);
             $this->assertObjectHasProperty('name', $client);
-            $this->assertObjectHasProperty('token', $client);
             $this->assertObjectHasProperty('lastUsed', $client);
         }
     }


### PR DESCRIPTION
Removes checking for token in `getAll` method tests to make them compatible with Gotify v3.